### PR TITLE
Capitalize all Ps in WordPress

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
-# What is the Wordpress Superdesk Publisher plugin?
-The Superdesk Wordpress Publisher plugin enables content to be sent from an instance of Sourcefabric's Superdesk newsroom management system (www.superdesk.org) and the Wordpress instance it's installed on. Superdesk itself is open source (https://github.com/superdesk/superdesk).
+# What is the WordPress Superdesk Publisher plugin?
+The Superdesk WordPress Publisher plugin enables content to be sent from an instance of Sourcefabric's Superdesk newsroom management system (www.superdesk.org) and the WordPress instance it's installed on. Superdesk itself is open source (https://github.com/superdesk/superdesk).
 
-# What does the Wordpress Superdesk Publisher plugin do?
-When both Superdesk and the Wordpress Superdesk Publisher plugin are correctly configured, a Superdesk user publishes an item and it is automatically published in Wordpress. Users can still log in to Wordpress to administer the site.
+# What does the WordPress Superdesk Publisher plugin do?
+When both Superdesk and the WordPress Superdesk Publisher plugin are correctly configured, a Superdesk user publishes an item and it is automatically published in WordPress. Users can still log in to WordPress to administer the site.
 
 # How does it work?
-Superdesk supports the IPTC's industry standard ninjs (http://dev.iptc.org/ninjs), which standardizes the representation of news in JSON - a lightweight, easy-to-parse, data interchange format. The Superdesk Wordpress Publisher plugin will also enable multiple instances of Wordpress to receive content from a single instance of Superdesk; output channels are defined in Superdesk, so you could have multiple, or only one, or none at all (which wouldn't be that useful but still possible (wink)). This plugin should also work with other information sources that use ninjs.
+Superdesk supports the IPTC's industry standard ninjs (http://dev.iptc.org/ninjs), which standardizes the representation of news in JSON - a lightweight, easy-to-parse, data interchange format. The Superdesk WordPress Publisher plugin will also enable multiple instances of WordPress to receive content from a single instance of Superdesk; output channels are defined in Superdesk, so you could have multiple, or only one, or none at all (which wouldn't be that useful but still possible (wink)). This plugin should also work with other information sources that use ninjs.
 
-We've created a table to map fields between Superdesk's ninjs implementation and Wordpress: https://wiki.sourcefabric.org/display/NR/Ninjs+to+WP+data+structure+mapping
+We've created a table to map fields between Superdesk's ninjs implementation and WordPress: https://wiki.sourcefabric.org/display/NR/Ninjs+to+WP+data+structure+mapping
 
 On the Superdesk side, there are publishing providers which are the ones in charge of actually delivering the content in the configured format and delivery mechanism; this is done on a publishing channel basis in Superdesk.
 
 Stories are checked in Superdesk as published, then the publishing providers take over to distribute the content.
 
-The Superdesk Wordpress Publisher plugin currently uses Superdesk's HTTP PUSH to receive content in ninjs. When the plugin receives new content via HTTP PUSH, it automatically loads this content into the Wordpress database via the REST API.
+The Superdesk WordPress Publisher plugin currently uses Superdesk's HTTP PUSH to receive content in ninjs. When the plugin receives new content via HTTP PUSH, it automatically loads this content into the WordPress database via the REST API.
 
 # Settings menu
-A settings menu in Wordpress lets you customize the way Wordpress handles content from Superdesk. For example, you can map Superdesk's categories to Wordpress's tags, or use Superdesk subjects as categories. Authors, copyright information, post status, and default categories are just some of the Wordpress fields that can be controlled from the Settings menu.
+A settings menu in WordPress lets you customize the way WordPress handles content from Superdesk. For example, you can map Superdesk's categories to WordPress's tags, or use Superdesk subjects as categories. Authors, copyright information, post status, and default categories are just some of the WordPress fields that can be controlled from the Settings menu.
 
 # What's next?
-We do not have a native Wordpress publishing provider in Superdesk, and there is no plan to write one in the current roadmap. We prefer to use ninjs as an standard interchange format.
+We do not have a native WordPress publishing provider in Superdesk, and there is no plan to write one in the current roadmap. We prefer to use ninjs as an standard interchange format.

--- a/admin/admin.php
+++ b/admin/admin.php
@@ -286,7 +286,7 @@ function superdesk_admin() {
                   </tr>
                   <tr>
                       <th scope="row">
-                          Import Superdesk categories as Wordpress categories
+                          Import Superdesk categories as WordPress categories
                       </th>
                       <td>
                           <fieldset>
@@ -319,7 +319,7 @@ function superdesk_admin() {
                                   if ($settings['subject-type'] == 'tags' || !$settings['subject-type'] || $settings['subject-type'] == null) {
                                     echo(' checked');
                                   }
-                                  ?>> Wordpress tags
+                                  ?>> WordPress tags
                               </label>
                               <br>
                               <label for="categories">
@@ -327,7 +327,7 @@ function superdesk_admin() {
                                   if ($settings['subject-type'] == 'categories') {
                                     echo(' checked');
                                   }
-                                  ?>> Wordpress categories
+                                  ?>> WordPress categories
                               </label>
                           </fieldset>
                       </td>
@@ -597,7 +597,7 @@ function superdesk_admin() {
                   </tr>
                   <tr>
                       <th scope="row">
-                          Match Superdesk Content Profiles with Wordpress Post Formats 
+                          Match Superdesk Content Profiles with WordPress Post Formats 
                       </th>
                       <td>
                           <fieldset>
@@ -625,7 +625,7 @@ function superdesk_admin() {
                               <thead>
                                   <tr>
                                       <th>Superdesk Content Profile Name</th>
-                                      <th>Wordpress Post Format</th>
+                                      <th>WordPress Post Format</th>
                                       <th><a href="javascript:rowAddFunction();">Add row</a></th>
                                   </tr>
                               </thead>


### PR DESCRIPTION
Found some references that needed to change from "Wordpress" to "WordPress"