### PR TITLE
Fixes incorrectly wired setting

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -64,7 +64,7 @@ function superdesk_admin() {
         'slugline-ignored' => $_POST['slugline-ignored'],
         'priority_threshhold' => $_POST['priority_threshhold'],
         'download-images' => $_POST['download-images'],
-        'post-formats' => $_POST['download-images'],
+        'post-formats' => $_POST['post-formats'],
         'post-formats-table' => $resultArray,
         'location-modifier' => $_POST['location-modifier'],
         'update-log-option' => $_POST['update-log-option'],


### PR DESCRIPTION
Setting "download SD images" also updates the state of the "Match SD profiles to  WP post formats". This PR fixes the control wiring 🙂 